### PR TITLE
Fixed binding state regex

### DIFF
--- a/lease.go
+++ b/lease.go
@@ -75,18 +75,18 @@ type Lease struct {
 
 var (
 	decoders = map[*regexp.Regexp]func(*Lease, string){
-		regexp.MustCompile("(.*) {"):                         func(l *Lease, line string) { l.IP = net.ParseIP(line) },
-		regexp.MustCompile("cltt (?P<D>.*);"):                func(l *Lease, line string) { l.Cltt = parseTime(line) },
-		regexp.MustCompile("starts (?P<D>.*);"):              func(l *Lease, line string) { l.Starts = parseTime(line) },
-		regexp.MustCompile("ends (?P<D>.*);"):                func(l *Lease, line string) { l.Ends = parseTime(line) },
-		regexp.MustCompile("tsfp (?P<D>.*);"):                func(l *Lease, line string) { l.Tsfp = parseTime(line) },
-		regexp.MustCompile("tstp (?P<D>.*);"):                func(l *Lease, line string) { l.Tstp = parseTime(line) },
-		regexp.MustCompile("atsfp (?P<D>.*);"):               func(l *Lease, line string) { l.Atsfp = parseTime(line) },
-		regexp.MustCompile("cltt (?P<D>.*);"):                func(l *Lease, line string) { l.Cltt = parseTime(line) },
-		regexp.MustCompile("uid \"(?P<D>.*)\";"):             func(l *Lease, line string) { l.UID = line },
-		regexp.MustCompile("client-hostname \"(?P<D>.*)\";"): func(l *Lease, line string) { l.ClientHostname = line },
-		regexp.MustCompile("binding state (?P<D>.*);"):       func(l *Lease, line string) { l.BindingState = line },
-		regexp.MustCompile("next binding state (?P<D>.*);"):  func(l *Lease, line string) { l.NextBindingState = line },
+		regexp.MustCompile("(.*) {"):                           func(l *Lease, line string) { l.IP = net.ParseIP(line) },
+		regexp.MustCompile("cltt (?P<D>.*);"):                  func(l *Lease, line string) { l.Cltt = parseTime(line) },
+		regexp.MustCompile("starts (?P<D>.*);"):                func(l *Lease, line string) { l.Starts = parseTime(line) },
+		regexp.MustCompile("ends (?P<D>.*);"):                  func(l *Lease, line string) { l.Ends = parseTime(line) },
+		regexp.MustCompile("tsfp (?P<D>.*);"):                  func(l *Lease, line string) { l.Tsfp = parseTime(line) },
+		regexp.MustCompile("tstp (?P<D>.*);"):                  func(l *Lease, line string) { l.Tstp = parseTime(line) },
+		regexp.MustCompile("atsfp (?P<D>.*);"):                 func(l *Lease, line string) { l.Atsfp = parseTime(line) },
+		regexp.MustCompile("cltt (?P<D>.*);"):                  func(l *Lease, line string) { l.Cltt = parseTime(line) },
+		regexp.MustCompile(`uid "(?P<D>.*)";`):                 func(l *Lease, line string) { l.UID = line },
+		regexp.MustCompile(`client-hostname "(?P<D>.*)";`):     func(l *Lease, line string) { l.ClientHostname = line },
+		regexp.MustCompile(`(?m)^\s*binding state (?P<D>.*);`): func(l *Lease, line string) { l.BindingState = line },
+		regexp.MustCompile("next binding state (?P<D>.*);"):    func(l *Lease, line string) { l.NextBindingState = line },
 		regexp.MustCompile("hardware (?P<D>.*);"): func(l *Lease, line string) {
 			s := strings.SplitN(line, " ", 2)
 			l.Hardware.Hardware = s[0]


### PR DESCRIPTION
Fixed the regex used to extract the binding state of the lease

Using the current regular expression, it extracts:
- binding state
- next binding state
- rewind binding state

<img width="1013" alt="Screenshot1" src="https://user-images.githubusercontent.com/6676192/62414542-3326d300-b61d-11e9-9c62-122b0ad60b21.png">

With the new regular expression, it extracts only the binding state.

<img width="999" alt="Screenshot2" src="https://user-images.githubusercontent.com/6676192/62414541-3326d300-b61d-11e9-8b0a-0b06e008fb46.png">
