### PR TITLE
support time parsing with timezone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/npotts/go-dhcpd-leases
+
+go 1.19

--- a/lease.go
+++ b/lease.go
@@ -99,8 +99,13 @@ var (
 )
 
 /*parseTime from the off format of "6 2019/04/27 03:34:45;" adn returns a time struct*/
-func parseTime(s string) time.Time {
-	t, _ := time.Parse("2006/01/02 15:04:05", s[2:])
+func parseTime(s string) (t time.Time) {
+	match := regexp.MustCompile(`[a-zA-Z]{2,}$`)
+	if match.MatchString(s) {
+		t, _ = time.Parse("2006/01/02 15:04:05 MST", s[2:])
+	} else {
+		t, _ = time.Parse("2006/01/02 15:04:05", s[2:])
+	}
 	return t
 }
 

--- a/lease.go
+++ b/lease.go
@@ -74,6 +74,9 @@ type Lease struct {
 }
 
 var (
+	// determine of time has a timezone suffix
+	timeZoneRegex = regexp.MustCompile(`[a-zA-Z]{2,}$`)
+
 	decoders = map[*regexp.Regexp]func(*Lease, string){
 		regexp.MustCompile("(.*) {"):                           func(l *Lease, line string) { l.IP = net.ParseIP(line) },
 		regexp.MustCompile("cltt (?P<D>.*);"):                  func(l *Lease, line string) { l.Cltt = parseTime(line) },
@@ -100,8 +103,7 @@ var (
 
 /*parseTime from the off format of "6 2019/04/27 03:34:45;" adn returns a time struct*/
 func parseTime(s string) (t time.Time) {
-	match := regexp.MustCompile(`[a-zA-Z]{2,}$`)
-	if match.MatchString(s) {
+	if timeZoneRegex.MatchString(s) {
 		t, _ = time.Parse("2006/01/02 15:04:05 MST", s[2:])
 	} else {
 		t, _ = time.Parse("2006/01/02 15:04:05", s[2:])


### PR DESCRIPTION
Some systems (OpenBSD in my case) include the timezone inside the timestamps. Would be nice if this would be supported by this library.
Further, I created a **go.mod** file be compliant with Golang standards.