### PR TITLE
Fixed closing bracket error in parser.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -10,7 +10,7 @@ import (
 var (
 	lkwd       = []byte("\nlease ")
 	hkwd       = []byte("\nhost ")
-	closeParen = []byte("}")
+	closeParen = []byte("\n}")
 )
 
 /*Parse reads from a dhcpd.leases file and returns a list of leases.  Unknown fields are ignored


### PR DESCRIPTION
We found a bug where some UIDs from DHCP clients would send '}' and ']' characters in their UID. This would cause the array to be presumed closed while lease is being parsed. 

Simply added a newline before the closing bracket to fix this.